### PR TITLE
Forward "First delivery attemps" tracking events as "failure"

### DIFF
--- a/app/controllers/tracking_events_controller.rb
+++ b/app/controllers/tracking_events_controller.rb
@@ -9,14 +9,12 @@ class TrackingEventsController < ActionController::API
   before_action :authorize_request!
 
   def create
-    tracking_status = TrackingEvent.normalize_value_for(:status, tracking_event_params[:status])
-
     TrackingEvent.create!(
       source_id: tracking_event_params[:gfsId],
       carrier: tracking_event_params[:carrierName],
       message: tracking_event_params[:text],
       tracking_number: tracking_event_params[:parcelNumber],
-      status: TrackingEvent.statuses.include?(tracking_status) ? tracking_status : :unknown,
+      status: :unknown,
       payload: tracking_event_params.except(:tracking_events)
     )
 

--- a/app/models/tracking_event/status_detection.rb
+++ b/app/models/tracking_event/status_detection.rb
@@ -22,9 +22,13 @@ class TrackingEvent
     #
     # @return [String, nil]
     def detect_by_status
-      case TrackingEvent.normalize_value_for(:status, payload["status"])
+      tracking_status = TrackingEvent.normalize_value_for(:status, payload["status"])
+
+      case tracking_status
       when "awaiting_collection"
         "waiting"
+      when TrackingEvent.statuses.include?(tracking_status)
+        tracking_status
       else
         nil
       end

--- a/app/models/tracking_event/status_detection.rb
+++ b/app/models/tracking_event/status_detection.rb
@@ -27,6 +27,8 @@ class TrackingEvent
       case tracking_status
       when "awaiting_collection"
         "waiting"
+      when "in_transit"
+        "failure"
       when TrackingEvent.statuses.include?(tracking_status)
         tracking_status
       else

--- a/test/controllers/tracking_events_controller_test.rb
+++ b/test/controllers/tracking_events_controller_test.rb
@@ -23,11 +23,11 @@ class TrackingEventsControllerTest < ActionDispatch::IntegrationTest
     assert_response :ok
   end
 
-  test "recognizes differently formatted tracking event statuses" do
+  test "stores all tracking events with an unknown status" do
     post tracking_events_path, params: @payload, headers: { "x-gfs-token" => @token }
     last_tracking_event = TrackingEvent.last
 
-    assert_equal "out_for_delivery", last_tracking_event.status
+    assert_equal "unknown", last_tracking_event.status
   end
 
   test "unrecognized tracking statuses are stored with an unknown status" do

--- a/test/fixtures/tracking_events.yml
+++ b/test/fixtures/tracking_events.yml
@@ -8,6 +8,14 @@ to_normalize:
   tracking_number: <%= SecureRandom.hex(16) %>
   payload: { status: "AWAITING COLLECTION" }
 
+to_normalize_in_transit:
+  status: unknown
+  source_id: <%= SecureRandom.uuid %>
+  carrier: EVRi
+  message: It's a test.
+  tracking_number: <%= SecureRandom.hex(16) %>
+  payload: { status: "IN TRANSIT" }
+
 pushed:
   status: delivered
   source_id: <%= SecureRandom.uuid %>

--- a/test/models/tracking_event_test.rb
+++ b/test/models/tracking_event_test.rb
@@ -11,6 +11,14 @@ class TrackingEventTest < ActiveSupport::TestCase
     end
   end
 
+  test "stores an 'in transit' status as failure" do
+    to_normalize_tracking_event = tracking_events(:to_normalize_in_transit)
+
+    assert_changes -> { to_normalize_tracking_event.reload.status }, to: "failure" do
+      to_normalize_tracking_event.detect_status
+    end
+  end
+
   test "schedules a tracking event with an unknown to be normalized after creation" do
     assert_enqueued_jobs 1, only: TrackingEvents::StatusDetectionJob do
       TrackingEvent.create!(source_id: SecureRandom.uuid, carrier: "FedEx", message: "Something unknown", tracking_number: SecureRandom.hex(16))


### PR DESCRIPTION
Before this change, we would detect a tracking event with status "IN TRANSIT" as an `in_transit` status.

With this change, we are instead detecting "IN TRANSIT" as `failure`.

I decided to move the detection phase entirely to the background job (see 6ce5818e9de4dccf86b78cf81f1bcd228eb41b5b). Strictly speaking, that wouldn't have been necessary - we could have also passed in a not-yet-persisted `TrackingEvent` to the `TrackingEvent::StatusDetection` class to get the job done.

However, that way we're getting another benefit: there's less logic involved when persisting the tracking event, and we don't risk any failures there which would mean we would need to resend events via the carrier (which they afaik don't do normally).